### PR TITLE
Fix gradient calculation

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ def solve_sudoku(initial_clues,
                 if g != 0:
                     pred = (p[r, c] * np.arange(1, 10)).sum()
                     err = 2 * (pred - g)
-                    grad[r, c] += w_giv * err * np.arange(1, 10) * p[r, c] * (1 - p[r, c]) # calculate loss
+                    grad[r, c] += w_giv * err * np.arange(1, 10)
 
         for d in range(9):
             row_sum = p[:, :, d].sum(axis=1, keepdims=True)


### PR DESCRIPTION
## Summary
- fix givens term to compute gradient with respect to probability before applying the chain rule

## Testing
- `python3 main.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684158dfae44832f949722277ad8f8dd